### PR TITLE
CI: Remove pin to nix v2.18

### DIFF
--- a/.github/workflows/cache-build-results.yml
+++ b/.github/workflows/cache-build-results.yml
@@ -28,12 +28,6 @@ jobs:
         with:
           path: "code/system-configurations"
       - uses: DeterminateSystems/nix-installer-action@main
-        # TODO: home-manager's `mkOutOfStoreSymlink` doesn't work on nix v2.19
-        # so I'm pinning v2.18:
-        # https://github.com/nix-community/home-manager/issues/4692
-        # https://github.com/NixOS/nix/issues/9579
-        with:
-          source-tag: v0.13.1
       - uses: cachix/cachix-action@ad2ddac53f961de1989924296a1f236fcfbaa4fc # v15
         with:
           name: bigolu

--- a/.github/workflows/publish-shell-executable.yml
+++ b/.github/workflows/publish-shell-executable.yml
@@ -31,12 +31,6 @@ jobs:
         with:
           path: "code/system-configurations"
       - uses: DeterminateSystems/nix-installer-action@main
-        # TODO: bundle fails with latest so I'm pinning the same version I
-        # pinned in the cache workflow
-        # https://github.com/nix-community/home-manager/issues/4692
-        # https://github.com/NixOS/nix/issues/9579
-        with:
-          source-tag: v0.13.1
       - uses: cachix/cachix-action@ad2ddac53f961de1989924296a1f236fcfbaa4fc # v15
         with:
           name: bigolu

--- a/.github/workflows/renovate-post-upgrade-task.yml
+++ b/.github/workflows/renovate-post-upgrade-task.yml
@@ -41,12 +41,6 @@ jobs:
           # https://github.com/stefanzweifel/git-auto-commit-action?tab=readme-ov-file#commits-made-by-this-action-do-not-trigger-new-workflow-runs
           token: ${{ steps.bigolu-bot-app-token.outputs.token }}
       - uses: DeterminateSystems/nix-installer-action@main
-        # TODO: home-manager's `mkOutOfStoreSymlink` doesn't work on nix v2.19
-        # so I'm pinning v2.18:
-        # https://github.com/nix-community/home-manager/issues/4692
-        # https://github.com/NixOS/nix/issues/9579
-        with:
-          source-tag: v0.13.1
       - uses: cachix/cachix-action@ad2ddac53f961de1989924296a1f236fcfbaa4fc # v15
         with:
           name: bigolu

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -24,12 +24,6 @@ jobs:
         with:
           path: "code/system-configurations"
       - uses: DeterminateSystems/nix-installer-action@main
-        # TODO: home-manager's `mkOutOfStoreSymlink` doesn't work on nix v2.19
-        # so I'm pinning v2.18:
-        # https://github.com/nix-community/home-manager/issues/4692
-        # https://github.com/NixOS/nix/issues/9579
-        with:
-          source-tag: v0.13.1
       - uses: cachix/cachix-action@ad2ddac53f961de1989924296a1f236fcfbaa4fc # v15
         with:
           name: bigolu


### PR DESCRIPTION
The upstream issue appears to be fixed by https://github.com/NixOS/nix/pull/10456.

...and if not, I'd be glad to know!